### PR TITLE
暗号通貨ランクをランクテーブル、ヒストリーテーブルへ分割し保存処理を変更

### DIFF
--- a/src/app/Console/Commands/FetchMarketCapitalizationCommand.php
+++ b/src/app/Console/Commands/FetchMarketCapitalizationCommand.php
@@ -68,7 +68,7 @@ class FetchMarketCapitalizationCommand extends Command
 
     /**
      * Execute the console command.
-     * $ docker compose exec app php artisan app:fetch-market-capitalization-command
+     * $ docker compose exec app php artisan app:fetch-market-capitalization 1 10
      */
     public function handle(): void
     {

--- a/src/app/Models/DigitalCurrency.php
+++ b/src/app/Models/DigitalCurrency.php
@@ -23,7 +23,6 @@ class DigitalCurrency extends Model
         'symbol',
         'price',
         'market_cap',
-        'market_cap_rank',
     ];
 
     /**
@@ -36,6 +35,5 @@ class DigitalCurrency extends Model
         'symbol' => 'string',
         'price' => 'double',
         'market_cap' => 'double',
-        'market_cap_rank' => 'integer',
     ];
 }

--- a/src/app/Models/DigitalCurrencyRanking.php
+++ b/src/app/Models/DigitalCurrencyRanking.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+
+/**
+ * class DigitalCurrencyRanking
+ *
+ * @method static \Illuminate\Database\Eloquent\Builder|DigitalCurrency newModelQuery()
+ * @method static \Illuminate\Database\Eloquent\Builder|DigitalCurrency newQuery()
+ * @method static \Illuminate\Database\Eloquent\Builder|DigitalCurrency query()
+ */
+class DigitalCurrencyRanking extends Model
+{
+    /**
+     * The attributes that are mass assignable.
+     *
+     * @var array<int, string>
+     */
+    protected $fillable = [
+        'digital_currency_id',
+        'ranking',
+    ];
+
+    /**
+     * The attributes that should be cast.
+     *
+     * @var array<string, string>
+     */
+    protected $casts = [
+        'digital_currency_id' => 'integer',
+        'ranking' => 'integer',
+    ];
+}

--- a/src/app/Models/DigitalCurrencyRankingHistory.php
+++ b/src/app/Models/DigitalCurrencyRankingHistory.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+
+/**
+ * class DigitalCurrencyRankingHistory
+ *
+ * @method static \Illuminate\Database\Eloquent\Builder|DigitalCurrency newModelQuery()
+ * @method static \Illuminate\Database\Eloquent\Builder|DigitalCurrency newQuery()
+ * @method static \Illuminate\Database\Eloquent\Builder|DigitalCurrency query()
+ */
+class DigitalCurrencyRankingHistory extends Model
+{
+    /**
+     * The attributes that are mass assignable.
+     *
+     * @var array<int, string>
+     */
+    protected $fillable = [
+        'digital_currency_id',
+        'price',
+        'market_cap',
+        'ranking',
+        'fetched_date',
+    ];
+
+    /**
+     * The attributes that should be cast.
+     *
+     * @var array<string, string>
+     */
+    protected $casts = [
+        'digital_currency_id' => 'integer',
+        'price' => 'double',
+        'market_cap' => 'integer',
+        'ranking' => 'integer',
+        'fetched_date' => 'date',
+    ];
+}

--- a/src/app/UseCases/MarketCapitalizationRanking/FetchCommandUseCase.php
+++ b/src/app/UseCases/MarketCapitalizationRanking/FetchCommandUseCase.php
@@ -4,23 +4,35 @@ namespace App\UseCases\MarketCapitalizationRanking;
 
 use App\Gateway\CoinMarketCapGateway;
 use App\Models\DigitalCurrency;
+use App\Models\DigitalCurrencyRanking;
+use App\Models\DigitalCurrencyRankingHistory;
 use App\UseCases\UseCaseInterface;
+use Carbon\Carbon;
 use Illuminate\Http\Client\RequestException;
 use Illuminate\Http\Client\Response;
+use Illuminate\Support\Facades\DB;
 
 class FetchCommandUseCase implements UseCaseInterface
 {
     private CoinMarketCapGateway $coinMarketCapGateway;
 
-    protected DigitalCurrency $digitalCurrency;
+    private DigitalCurrency $digitalCurrency;
+
+    private DigitalCurrencyRanking $digitalCurrencyRanking;
+
+    private DigitalCurrencyRankingHistory $digitalCurrencyRankingHistory;
 
     public function __construct(
         CoinMarketCapGateway $coinMarketCapGateway,
-        DigitalCurrency $digitalCurrency
+        DigitalCurrency $digitalCurrency,
+        DigitalCurrencyRanking $digitalCurrencyRanking,
+        DigitalCurrencyRankingHistory $digitalCurrencyRankingHistory
     )
     {
         $this->coinMarketCapGateway = $coinMarketCapGateway;
         $this->digitalCurrency = $digitalCurrency;
+        $this->digitalCurrencyRanking = $digitalCurrencyRanking;
+        $this->digitalCurrencyRankingHistory = $digitalCurrencyRankingHistory;
     }
 
     /**
@@ -35,6 +47,9 @@ class FetchCommandUseCase implements UseCaseInterface
             'limit' => $limit,
         ]));
 
+        $this->digitalCurrencyRanking->newQuery()->delete();
+
+        // TODO: トランザクションかける
         $digitalCurrenciesResponse->each(function (Response $response) {
             foreach ($response->object()->data as $digitalCurrency) {
                 $this->digitalCurrency->newQuery()->updateOrinsert(
@@ -46,7 +61,36 @@ class FetchCommandUseCase implements UseCaseInterface
                         'symbol' => $digitalCurrency->symbol,
                         'price' => $digitalCurrency->quote->USD->price,
                         'market_cap' => $digitalCurrency->quote->USD->market_cap,
-                        'market_cap_rank' => $digitalCurrency->cmc_rank,
+                    ]
+                );
+
+                // TODO: もっとすっきりかけないか？一発で取得できるメソッドなどないか
+                $lastInsertOrUpdateId = DB::getPdo()->lastInsertId();
+                if (!$lastInsertOrUpdateId) {
+                    $lastInsertOrUpdateId = $this->digitalCurrency
+                        ->newQuery()
+                        ->select('id')
+                        ->where(['symbol' => $digitalCurrency->symbol])
+                        ->get()->first()->id;
+                }
+
+                $this->digitalCurrencyRanking->newQuery()->insert(
+                    [
+                        'digital_currency_id' => $lastInsertOrUpdateId,
+                        'ranking' => $digitalCurrency->cmc_rank,
+                    ]
+                );
+
+                $today = Carbon::today();
+                // TODO: 日付で全削除しておく？
+
+                $this->digitalCurrencyRankingHistory->newQuery()->insert(
+                    [
+                        'digital_currency_id' => $lastInsertOrUpdateId,
+                        'price' => $digitalCurrency->quote->USD->price,
+                        'market_cap' => $digitalCurrency->quote->USD->market_cap,
+                        'ranking' => $digitalCurrency->cmc_rank,
+                        'fetched_date' => $today,
                     ]
                 );
             }

--- a/src/database/migrations/2023_06_06_145415_digital_currency_rankings_table.php
+++ b/src/database/migrations/2023_06_06_145415_digital_currency_rankings_table.php
@@ -11,12 +11,10 @@ return new class extends Migration
      */
     public function up(): void
     {
-        Schema::create('digital_currencies', function (Blueprint $table) {
+        Schema::create('digital_currency_rankings', function (Blueprint $table) {
             $table->id();
-            $table->string('name')->comment('通貨名');
-            $table->string('symbol')->comment('シンボル');
-            $table->decimal('price', 20, 8)->comment('市場価格');
-            $table->decimal('market_cap', 20, 8)->comment('時価総額');
+            $table->foreignId('digital_currency_id')->constrained('digital_currencies');
+            $table->integer('ranking')->comment('時価総額ランキング');
             $table->timestamps();
         });
     }
@@ -26,6 +24,6 @@ return new class extends Migration
      */
     public function down(): void
     {
-        Schema::dropIfExists('digital_currencies');
+        Schema::dropIfExists('digital_currency_rankings');
     }
 };

--- a/src/database/migrations/2023_06_06_154846_digital_currency_ranking_histories_table.php
+++ b/src/database/migrations/2023_06_06_154846_digital_currency_ranking_histories_table.php
@@ -11,12 +11,13 @@ return new class extends Migration
      */
     public function up(): void
     {
-        Schema::create('digital_currencies', function (Blueprint $table) {
+        Schema::create('digital_currency_ranking_histories', function (Blueprint $table) {
             $table->id();
-            $table->string('name')->comment('通貨名');
-            $table->string('symbol')->comment('シンボル');
+            $table->foreignId('digital_currency_id')->constrained('digital_currencies');
             $table->decimal('price', 20, 8)->comment('市場価格');
             $table->decimal('market_cap', 20, 8)->comment('時価総額');
+            $table->integer('ranking')->comment('時価総額ランキング');
+            $table->date('fetched_date')->comment('データ取得日');
             $table->timestamps();
         });
     }
@@ -26,6 +27,6 @@ return new class extends Migration
      */
     public function down(): void
     {
-        Schema::dropIfExists('digital_currencies');
+        Schema::dropIfExists('digital_currency_ranking_histories');
     }
 };


### PR DESCRIPTION
## 概要
#3 
#4 

## 対応内容
 - digital_currency_rankingテーブルを追加
 - digital_currency_ranking_historyテーブルを追加
 - FetchMarketCapitalizationCommandへランキングとランキングヒストリーへ削除や保存する処理を実装

## 備考
php artisan migrateの実行が必要