### PR TITLE
暗合通貨時価総額ランキングを取得できるAPIを実装

### DIFF
--- a/src/app/Http/Controllers/DigitalCurrencyRankings/IndexController.php
+++ b/src/app/Http/Controllers/DigitalCurrencyRankings/IndexController.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Http\Controllers\DigitalCurrencyRankings;
 
 use App\Http\Controllers\Controller;
+use App\Http\Requests\DigitalCurrencyRankings\IndexRequest;
 use App\Http\Resources\DigitalCurrencyRankings\IndexResource;
 use App\UseCases\DigitalCurrencyRankings\IndexUseCase;
 use Illuminate\Http\Resources\Json\ResourceCollection;
@@ -17,6 +18,18 @@ class IndexController extends Controller
     private IndexUseCase $indexUseCase;
 
     /**
+     * 取得するランキングの最大数
+     * @var int
+     */
+    private int $initLimit = 100;
+
+    /**
+     * 昇順または降順
+     * @var string
+     */
+    private string $initSort = 'desc';
+
+    /**
      * @param IndexUseCase $indexUseCase
      */
     public function __construct(IndexUseCase $indexUseCase)
@@ -25,11 +38,15 @@ class IndexController extends Controller
     }
 
     /**
+     * @param IndexRequest $request
      * @return ResourceCollection
      */
-    public function __invoke(): ResourceCollection
+    public function __invoke(IndexRequest $request): ResourceCollection
     {
-        $digitalCurrencyRankings = $this->indexUseCase->handle();
+        $limit = $request->input('limit') ? $request->input('limit') : $this->initLimit;
+        $sort = $request->input('sort') ? $request->input('sort') : $this->initSort;
+
+        $digitalCurrencyRankings = $this->indexUseCase->handle($limit, $sort);
         return IndexResource::collection($digitalCurrencyRankings);
     }
 }

--- a/src/app/Http/Controllers/DigitalCurrencyRankings/IndexController.php
+++ b/src/app/Http/Controllers/DigitalCurrencyRankings/IndexController.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Controllers\DigitalCurrencyRankings;
+
+use App\Http\Controllers\Controller;
+
+class IndexController extends Controller
+{
+    public function __construct()
+    {
+    }
+
+
+    public function __invoke()
+    {
+        return 'Hello IndexController';
+    }
+}

--- a/src/app/Http/Controllers/DigitalCurrencyRankings/IndexController.php
+++ b/src/app/Http/Controllers/DigitalCurrencyRankings/IndexController.php
@@ -5,16 +5,31 @@ declare(strict_types=1);
 namespace App\Http\Controllers\DigitalCurrencyRankings;
 
 use App\Http\Controllers\Controller;
+use App\Http\Resources\DigitalCurrencyRankings\IndexResource;
+use App\UseCases\DigitalCurrencyRankings\IndexUseCase;
+use Illuminate\Http\Resources\Json\ResourceCollection;
 
 class IndexController extends Controller
 {
-    public function __construct()
+    /**
+     * @var IndexUseCase
+     */
+    private IndexUseCase $indexUseCase;
+
+    /**
+     * @param IndexUseCase $indexUseCase
+     */
+    public function __construct(IndexUseCase $indexUseCase)
     {
+        $this->indexUseCase = $indexUseCase;
     }
 
-
-    public function __invoke()
+    /**
+     * @return ResourceCollection
+     */
+    public function __invoke(): ResourceCollection
     {
-        return 'Hello IndexController';
+        $digitalCurrencyRankings = $this->indexUseCase->handle();
+        return IndexResource::collection($digitalCurrencyRankings);
     }
 }

--- a/src/app/Http/Requests/DigitalCurrencyRankings/IndexRequest.php
+++ b/src/app/Http/Requests/DigitalCurrencyRankings/IndexRequest.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Requests\DigitalCurrencyRankings;
+
+use Illuminate\Contracts\Validation\ValidationRule;
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rule;
+
+class IndexRequest extends FormRequest
+{
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array<string, ValidationRule|array|string>
+     */
+    public function rules(): array
+    {
+        return [
+            'limit' => ['nullable', 'integer', 'min:1', 'max:500'],
+            'sort' => ['nullable', 'string', Rule::in(['asc', 'desc'])],
+        ];
+    }
+
+    /**
+     * @return void
+     */
+    public function passedValidation(): void
+    {
+        $this->merge([
+            'limit' => (int)$this->input('limit'),
+        ]);
+    }
+}

--- a/src/app/Http/Resources/DigitalCurrencyRankings/IndexResource.php
+++ b/src/app/Http/Resources/DigitalCurrencyRankings/IndexResource.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Resources\DigitalCurrencyRankings;
+
+use App\Models\DigitalCurrency;
+use App\Models\DigitalCurrencyRanking;
+use Illuminate\Http\Request;
+use Illuminate\Http\Resources\Json\JsonResource;
+
+/**
+ * @property DigitalCurrency digitalCurrency
+ * @mixin DigitalCurrencyRanking
+ */
+class IndexResource extends JsonResource
+{
+    public function toArray(Request $request): array
+    {
+        return [
+            'rank' => $this->ranking,
+            'symbol' => $this->digitalCurrency->symbol,
+            'name' => $this->digitalCurrency->name,
+            'marketCap' => $this->digitalCurrency->market_cap,
+            'price' => $this->digitalCurrency->price,
+        ];
+    }
+}

--- a/src/app/Models/DigitalCurrency.php
+++ b/src/app/Models/DigitalCurrency.php
@@ -6,6 +6,7 @@ namespace App\Models;
 
 use Eloquent;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Support\Carbon;
 
 /**
@@ -55,4 +56,12 @@ class DigitalCurrency extends Model
         'price' => 'double',
         'market_cap' => 'double',
     ];
+
+    /**
+     * @return HasMany
+     */
+    public function digitalCurrencyRankings(): HasMany
+    {
+        return $this->hasMany(DigitalCurrencyRanking::class);
+    }
 }

--- a/src/app/Models/DigitalCurrencyRanking.php
+++ b/src/app/Models/DigitalCurrencyRanking.php
@@ -6,6 +6,7 @@ namespace App\Models;
 
 use Eloquent;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Support\Carbon;
 
 /**
@@ -47,4 +48,12 @@ class DigitalCurrencyRanking extends Model
         'digital_currency_id' => 'integer',
         'ranking' => 'integer',
     ];
+
+    /**
+     * @return BelongsTo
+     */
+    public function digitalCurrency(): BelongsTo
+    {
+        return $this->belongsTo(DigitalCurrency::class);
+    }
 }

--- a/src/app/Services/DigitalCurrencyRankings/DigitalCurrencyRankingsFetcher.php
+++ b/src/app/Services/DigitalCurrencyRankings/DigitalCurrencyRankingsFetcher.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\DigitalCurrencyRankings;
+
+use App\Models\DigitalCurrencyRanking;
+use Illuminate\Support\Collection;
+
+class DigitalCurrencyRankingsFetcher
+{
+
+    /**
+     * @var DigitalCurrencyRanking
+     */
+    private DigitalCurrencyRanking $digitalCurrencyRanking;
+
+    /**
+     * @param DigitalCurrencyRanking $digitalCurrencyRanking
+     */
+    public function __construct(DigitalCurrencyRanking $digitalCurrencyRanking)
+    {
+        $this->digitalCurrencyRanking = $digitalCurrencyRanking;
+    }
+
+    /**
+     * @return Collection
+     */
+    public function fetch(): Collection
+    {
+        return $this->digitalCurrencyRanking->orderBy('ranking')->get();
+    }
+}

--- a/src/app/Services/DigitalCurrencyRankings/DigitalCurrencyRankingsFetcher.php
+++ b/src/app/Services/DigitalCurrencyRankings/DigitalCurrencyRankingsFetcher.php
@@ -24,10 +24,12 @@ class DigitalCurrencyRankingsFetcher
     }
 
     /**
+     * @param int|null $limit
+     * @param string|null $sort
      * @return Collection
      */
-    public function fetch(): Collection
+    public function fetch(?int $limit, ?string $sort): Collection
     {
-        return $this->digitalCurrencyRanking->orderBy('ranking')->get();
+        return $this->digitalCurrencyRanking->orderBy('ranking', $sort)->limit($limit)->get();
     }
 }

--- a/src/app/UseCases/DigitalCurrencyRankings/IndexUseCase.php
+++ b/src/app/UseCases/DigitalCurrencyRankings/IndexUseCase.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\UseCases\DigitalCurrencyRankings;
+
+use App\Services\DigitalCurrencyRankings\DigitalCurrencyRankingsFetcher;
+use App\UseCases\UseCaseInterface;
+use Illuminate\Support\Collection;
+
+class IndexUseCase implements UseCaseInterface
+{
+    /**
+     * @var DigitalCurrencyRankingsFetcher
+     */
+    private DigitalCurrencyRankingsFetcher $digitalCurrencyRankingsFetcher;
+
+    /**
+     * @param DigitalCurrencyRankingsFetcher $digitalCurrencyRankingsFetcher
+     */
+    public function __construct(DigitalCurrencyRankingsFetcher $digitalCurrencyRankingsFetcher)
+    {
+        $this->digitalCurrencyRankingsFetcher = $digitalCurrencyRankingsFetcher;
+    }
+
+    /**
+     * @return Collection
+     */
+    public function handle(): Collection
+    {
+        return $this->digitalCurrencyRankingsFetcher->fetch();
+    }
+}

--- a/src/app/UseCases/DigitalCurrencyRankings/IndexUseCase.php
+++ b/src/app/UseCases/DigitalCurrencyRankings/IndexUseCase.php
@@ -24,10 +24,12 @@ class IndexUseCase implements UseCaseInterface
     }
 
     /**
+     * @param int|null $limit
+     * @param string|null $sort
      * @return Collection
      */
-    public function handle(): Collection
+    public function handle(?int $limit, ?string $sort): Collection
     {
-        return $this->digitalCurrencyRankingsFetcher->fetch();
+        return $this->digitalCurrencyRankingsFetcher->fetch($limit, $sort);
     }
 }

--- a/src/routes/api.php
+++ b/src/routes/api.php
@@ -18,4 +18,4 @@ Route::middleware('auth:sanctum')->get('/user', function (Request $request) {
     return $request->user();
 });
 
-Route::get('/digital_currency-rankings', \App\Http\Controllers\DigitalCurrencyRankings\IndexController::class)->name('DigitalCurrencyRankingsIndex');
+Route::get('/digital-currency-rankings', \App\Http\Controllers\DigitalCurrencyRankings\IndexController::class)->name('DigitalCurrencyRankingsIndex');

--- a/src/routes/api.php
+++ b/src/routes/api.php
@@ -17,3 +17,5 @@ use Illuminate\Support\Facades\Route;
 Route::middleware('auth:sanctum')->get('/user', function (Request $request) {
     return $request->user();
 });
+
+Route::get('/digital_currency-rankings', \App\Http\Controllers\DigitalCurrencyRankings\IndexController::class)->name('DigitalCurrencyRankingsIndex');


### PR DESCRIPTION
## 概要
#2 

## 対応内容
 - 暗合通貨時価総額ランキング取得APIを実装
 - リクエストパラメータとして`limit`と`sort`を受け付ける

## 確認方法
 - Postman等で下記のURLへGETリクエスト
   - http://localhost/api/digital-currency-rankings?limit=10&sort=desc


↓↓ レスポンス例
```json
{
    "data": [
        {
            "rank": 8879,
            "symbol": "lccpy2s6qrj",
            "name": "totq5zafzw",
            "marketCap": 0.85552104,
            "price": 0.05487745
        },
        {
            "rank": 7269,
            "symbol": "u72f3bq42ve",
            "name": "egklspsnll9",
            "marketCap": 0.35391331,
            "price": 0.07313681
        }
    ]
}
```