### PR TITLE
テスト専用のDBを作成

### DIFF
--- a/compose.yml
+++ b/compose.yml
@@ -66,6 +66,7 @@ services:
         target: /var/lib/mysql
         volume:
           nocopy: true
+      - ./infra/docker/db:/docker-entrypoint-initdb.d
     environment:
       - MYSQL_DATABASE=${DB_DATABASE:-laravel}
       - MYSQL_USER=${DB_USERNAME:-phper}

--- a/infra/docker/db/init.sql
+++ b/infra/docker/db/init.sql
@@ -1,0 +1,2 @@
+CREATE DATABASE IF NOT EXISTS `laravel_test`;
+GRANT ALL ON *.* TO 'phper'@'%' ;

--- a/src/phpunit.xml
+++ b/src/phpunit.xml
@@ -21,8 +21,8 @@
         <env name="APP_ENV" value="testing"/>
         <env name="BCRYPT_ROUNDS" value="4"/>
         <env name="CACHE_DRIVER" value="array"/>
-        <!-- <env name="DB_CONNECTION" value="sqlite"/> -->
-        <!-- <env name="DB_DATABASE" value=":memory:"/> -->
+        <server name="DB_CONNECTION" value="mysql"/>
+        <server name="DB_DATABASE" value="laravel_test"/>
         <env name="MAIL_MAILER" value="array"/>
         <env name="QUEUE_CONNECTION" value="sync"/>
         <env name="SESSION_DRIVER" value="array"/>


### PR DESCRIPTION
## 概要
#12 

## 対応内容
・コンテナ作成時にテスト用のDBが作成されるようにinit.sqlを作成し、composeファイルを変更
・phpunit.xmlを編集してテスト時にはテスト用のDBが使用されるようにした

## 確認方法
 - コンテナ、ボリューム削除
 - `docker-compose up -d`
 - テスト用DB laravel_test が作成されていればOK

## 備考
テスト時にテスト用DBが使用されているかは確認済み