### PR TITLE
フロントからAPIリクエストを行えるようにdocker networkの設定

### DIFF
--- a/compose.yml
+++ b/compose.yml
@@ -33,6 +33,8 @@ services:
       - DB_DATABASE=${DB_DATABASE:-laravel}
       - DB_USERNAME=${DB_USERNAME:-phper}
       - DB_PASSWORD=${DB_PASSWORD:-secret}
+    networks:
+      - dci
 
   web:
     build:
@@ -47,6 +49,8 @@ services:
       - type: bind
         source: ./src
         target: /workspace
+    networks:
+      - dci
 
   db:
     build:
@@ -72,3 +76,8 @@ services:
       - MYSQL_USER=${DB_USERNAME:-phper}
       - MYSQL_PASSWORD=${DB_PASSWORD:-secret}
       - MYSQL_ROOT_PASSWORD=${DB_PASSWORD:-secret}
+    networks:
+      - dci
+networks:
+  dci:
+    external: true


### PR DESCRIPTION
## 概要
#22 

## 対応内容
 - compose.ymlで属するネットワークを指定するように変更