### PR TITLE
digital_currenciesテーブルへの保存処理を担うサービスクラスを実装

### DIFF
--- a/src/app/Services/DigitalCurrencies/DigitalCurrenciesReceiver.php
+++ b/src/app/Services/DigitalCurrencies/DigitalCurrenciesReceiver.php
@@ -1,0 +1,62 @@
+<?php
+
+namespace App\Services\DigitalCurrencies;
+
+use Illuminate\Support\Collection;
+use stdClass;
+
+class DigitalCurrenciesReceiver
+{
+    /** @var stdClass */
+    private stdClass $coinMarketCapDigitalCurrencies;
+
+    /** @var Collection */
+    private Collection $formatted;
+
+    /**
+     * CoinMarketCapから取得した暗合通貨データをプロパティにセット
+     *
+     * @param stdClass $coinMarketCapDigitalCurrencies
+     * @return $this
+     */
+    public function set(stdClass $coinMarketCapDigitalCurrencies): self
+    {
+        $this->coinMarketCapDigitalCurrencies = $coinMarketCapDigitalCurrencies;
+        return $this;
+    }
+
+    /**
+     * digital_currenciesテーブルの形に会うようにフォーマット
+     *
+     * @return $this
+     */
+    public function format(): self
+    {
+        if (!isset($this->coinMarketCapDigitalCurrencies)) {
+            throw new \LogicException('data not yet set.');
+        }
+
+        $this->formatted = collect([
+            'symbol' => $this->coinMarketCapDigitalCurrencies->symbol,
+            'name' => $this->coinMarketCapDigitalCurrencies->name,
+            'price' => $this->coinMarketCapDigitalCurrencies->quote->USD->price,
+            'market_cap' => $this->coinMarketCapDigitalCurrencies->quote->USD->market_cap,
+        ]);
+
+        return $this;
+    }
+
+    /**
+     * フォーマットしたデータを取得
+     *
+     * @return Collection
+     */
+    public function get(): Collection
+    {
+        if (!isset($this->formatted)) {
+            throw new \LogicException('data not yet formatted.');
+        }
+
+        return $this->formatted;
+    }
+}

--- a/src/app/Services/DigitalCurrencies/DigitalCurrencyStore.php
+++ b/src/app/Services/DigitalCurrencies/DigitalCurrencyStore.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace App\Services\DigitalCurrencies;
+
+use App\Models\DigitalCurrency;
+use Illuminate\Support\Collection;
+
+class DigitalCurrencyStore
+{
+    /**
+     * @var DigitalCurrency
+     */
+    private DigitalCurrency $digitalCurrency;
+
+    /**
+     * @param DigitalCurrency $digitalCurrency
+     */
+    public function __construct(DigitalCurrency $digitalCurrency)
+    {
+        $this->digitalCurrency = $digitalCurrency;
+    }
+
+    /**
+     * @param Collection $formattedDigitalCurrency
+     * @return void
+     */
+    public function updateOrInsert(Collection $formattedDigitalCurrency): void
+    {
+        $this->digitalCurrency->updateOrinsert(
+            [
+                'symbol' => $formattedDigitalCurrency->get('symbol')
+            ],
+            [
+                'name' => $formattedDigitalCurrency->get('name'),
+                'symbol' => $formattedDigitalCurrency->get('symbol'),
+                'price' => $formattedDigitalCurrency->get('price'),
+                'market_cap' => $formattedDigitalCurrency->get('market_cap'),
+            ]
+        );
+    }
+}


### PR DESCRIPTION
## 概要
#1 

## 対応内容
 - CoinMarketCapから取得したデータを整形するフォーマットクラスを作成
 - フォーマットされたデータを受け取り、テーブルへ保存するStoreクラスを作成

## 動作確認
 - `php artisan app:fetch-market-capitalization 1 10`
   - 上記を実行しdigital_currenciesテーブルにデータが保存されていることを確認する
